### PR TITLE
Notifications added to services and change service deletion to cancelation

### DIFF
--- a/mande_app/tests.py
+++ b/mande_app/tests.py
@@ -429,3 +429,39 @@ class TestMandeApp(TestCase):
         response = client.get('/mande_app/services/?id_user=6',content_type='application/json')
         assert len(response.data['data']) == 2
         assert response.status_code == 200
+
+    def test_service_cancelation(self):
+        client = Client()
+
+        data_s_1 = {
+            "id_user": 2,
+            "id_worker_job": 1,
+            "hours": 2,
+            "description": "Instalacion de lamparas en el baño"
+        }
+
+        client.post('/mande_app/services/', data=data_s_1)
+
+        response = client.delete('/mande_app/services/', data={"id_service": 1}, content_type='application/json')
+
+        assert response.status_code == 200
+        assert response.content.decode() == "Service with id 1 was canceled"
+
+    def test_service_cancelation_twice(self):
+        client = Client()
+
+        data_s_1 = {
+            "id_user": 2,
+            "id_worker_job": 1,
+            "hours": 2,
+            "description": "Instalacion de lamparas en el baño"
+        }
+
+        client.post('/mande_app/services/', data=data_s_1)
+
+        client.delete('/mande_app/services/', data={"id_service": 1}, content_type='application/json')
+
+        response = client.delete('/mande_app/services/', data={"id_service": 1}, content_type='application/json')
+
+        assert response.status_code == 401
+        assert response.content.decode() == "Service already ended or canceled"


### PR DESCRIPTION
Now some notifications are created in the following moments:
 - Worker add a new job offer
 - Worker cancel a job offer
 - Service request
 - Service finalization 
 - Service Cancelation
  
Both Worker and Customer receive a notificacion in each action related to the services.

Also, the services deletion don't destroy the record, instead set it as "canceled" in order to save the record.